### PR TITLE
Update WorldUtils.cs

### DIFF
--- a/SmartBuilding/src/Utilities/WorldUtils.cs
+++ b/SmartBuilding/src/Utilities/WorldUtils.cs
@@ -241,7 +241,8 @@ namespace SmartBuilding.Utilities
                             var hd = (HoeDirt)here.terrainFeatures[targetTile];
 
                             // 0 here means no fertilizer. This is a known change in 1.6.
-                            if (!hd.HasFertilizer())
+                            // To make it partially compatible with Ultimate Fertilizer (21318), use Contains instead. 
+                            if (!hd.fertilizer.Value.Contains(itemToPlace.ItemId))
                             {
                                 // Next, we want to check if there's already a crop here.
                                 if (hd.crop != null)
@@ -262,7 +263,7 @@ namespace SmartBuilding.Utilities
                                     I18n.SmartBuilding_Error_Fertiliser_AlreadyFertilised(), LogLevel.Warn);
 
                             // Now, we want to run the final check to see if the fertilization was successful.
-                            if (!hd.HasFertilizer())
+                            if (!hd.fertilizer.Value.Contains(itemToPlace.ItemId))
                                 // If there's still no fertilizer here, we need to refund the item.
                                 this.playerUtils.RefundItem(itemToPlace,
                                     I18n.SmartBuilding_Error_Fertiliser_IneligibleForFertilisation(), LogLevel.Warn);


### PR DESCRIPTION
The old MultiFertilizer has not been updated for 1.6 yet. Another mod called Ultimate Fertilizer now allows multi-fertilizer in a different way. These two lines makes Smart Building partially compatible with Ultimate Fertilizer, allowing multi-fertilizer on an empty dirt, and doesn't affect people who don't use that mod. (Ultimate Fertilizer has other functions, but those will need a huge compability patch)